### PR TITLE
Fix timer format switching threshold to 120 minutes

### DIFF
--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -483,8 +483,9 @@ const MqtDisplay = () => {
     }
   };
 
-  // Determine if we should switch to hour-inclusive display (based on total duration setting)
-  const isLongDuration = Math.floor(safeDuration / 60) > 56;
+  // Determine if we should switch to hour-inclusive display based on current time value
+  const currentTotalSeconds = Math.max(0, safeTime);
+  const isLongDuration = Math.floor(currentTotalSeconds / 60) >= 60;
 
   // Dynamic font size based on actual digit count and screen size
   const getDynamicFontSize = () => {

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -580,7 +580,56 @@ const MqtDisplay = () => {
       baseSize = 60; // Original size for short text
     }
 
-    return Math.round(baseSize * scaleFactor * 1.3); // Increased by 30%
+    const baseComputed = Math.round(baseSize * scaleFactor * 1.3);
+
+    // Constrain font size to fit within the circle and background
+    const baseStrokeWidth = circleStyle === 'fat' ? 16 : circleStyle === 'bw' ? 2 : 8;
+    const strokeW = getResponsiveStrokeWidth(baseStrokeWidth);
+    const padding = 10 + (hideClockBackground ? 0 : 4);
+    const innerDiameter = 2 * (radius - strokeW / 2 - padding);
+    const heightMax = innerDiameter * 0.9;
+
+    const charFactor = 0.6; // width per digit relative to font size
+    const colonFactor = 0.3; // width for ':' relative to font size
+    const unitFactor = 0.35; // width for unit letters like 'h'
+
+    const totalForDisplay = countUp ? Math.max(0, time) : Math.max(0, time);
+    const hourDigits = String(Math.floor(totalForDisplay / 3600)).length || 1;
+    const secondsVal = Math.floor(totalForDisplay % 60);
+    const secondsDigits = String(secondsVal).length;
+    const minutesTotal = Math.floor(totalForDisplay / 60);
+    const minuteDigits = String(minutesTotal).length || 1;
+
+    let widthFactor;
+    if (timeFormat === 'mm') {
+      if (isLongDuration) {
+        // HHMM (no 'm') but with 'h'
+        widthFactor = charFactor * (hourDigits + 2) + unitFactor; // hours + 2 minute digits + 'h'
+      } else if ((countUp ? time : Math.max(0, time)) < 60) {
+        // seconds only (SS)
+        widthFactor = charFactor * secondsDigits;
+      } else {
+        // minutes only (MM...)
+        widthFactor = charFactor * minuteDigits;
+      }
+    } else if (timeFormat === 'mm:ss') {
+      if (isLongDuration) {
+        // HH:MM (no 'm') but with 'h' and colon
+        widthFactor = charFactor * (hourDigits + 2) + unitFactor + colonFactor;
+      } else {
+        // MM:SS
+        widthFactor = charFactor * (minuteDigits + 2) + colonFactor;
+      }
+    } else {
+      // Fallback based on text length
+      widthFactor = charFactor * textLength;
+    }
+
+    if (!widthFactor || widthFactor <= 0) widthFactor = charFactor * 2; // safety
+
+    const widthMax = innerDiameter / widthFactor;
+    const finalSize = Math.floor(Math.min(baseComputed, widthMax * 0.98, heightMax));
+    return finalSize;
   };
 
   // Digit clicking functions
@@ -814,7 +863,7 @@ const MqtDisplay = () => {
           const hourStr = String(hours);
           const minuteStr = String(minutesInHour).padStart(2, '0');
 
-          const totalWidth = (hourStr.length * charWidth) + unitWidth + (2 * charWidth) + unitWidth; // H + 'h' + MM + 'm'
+          const totalWidth = (hourStr.length * charWidth) + unitWidth + (2 * charWidth); // H + 'h' + MM
           const startX = 120 - totalWidth / 2;
 
           // Render hour digits
@@ -914,21 +963,7 @@ const MqtDisplay = () => {
             );
           }
 
-          // 'm' unit
-          const mX = minutesStart + (2 * charWidth) + (unitWidth / 2);
-          elements.push(
-            <text
-              key="unit-m"
-              x={mX}
-              y={125}
-              textAnchor="middle"
-              fontFamily={font}
-              fontSize={fontSize}
-              fill={dynamicTextColor}
-            >
-              m
-            </text>
-          );
+
         }
         // Check if we should switch to SS format (last minute)
         else if (totalTime < 60) {
@@ -1088,8 +1123,8 @@ const MqtDisplay = () => {
           const hourStr = String(hours);
           const minuteStr = String(minutesInHour).padStart(2, '0');
 
-          // width: H + 'h' + ':' + MM + 'm'
-          const totalWidth = (hourStr.length * charWidth) + unitWidth + colonWidth + (2 * charWidth) + unitWidth;
+          // width: H + 'h' + ':' + MM
+          const totalWidth = (hourStr.length * charWidth) + unitWidth + colonWidth + (2 * charWidth);
           const startX = 120 - totalWidth / 2;
 
           // Hours
@@ -1205,21 +1240,7 @@ const MqtDisplay = () => {
             );
           }
 
-          // 'm' unit
-          const mX = minutesStart + (2 * charWidth) + (unitWidth / 2);
-          elements.push(
-            <text
-              key="unit-m"
-              x={mX}
-              y={125}
-              textAnchor="middle"
-              fontFamily={font}
-              fontSize={fontSize}
-              fill={dynamicTextColor}
-            >
-              m
-            </text>
-          );
+
         } else {
           const { totalSeconds } = getTimeComponents();
 

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -1509,8 +1509,24 @@ const MqtDisplay = () => {
     return markings;
   };
 
+  const handleDisplayClick = (e) => {
+    const svgElement = e.currentTarget.querySelector('.circle-svg');
+    if (!svgElement) { setIsRunning(prev => !prev); return; }
+    const svgRect = svgElement.getBoundingClientRect();
+    const centerX = svgRect.left + svgRect.width / 2;
+    const centerY = svgRect.top + svgRect.height / 2;
+    const dx = e.clientX - centerX;
+    const dy = e.clientY - centerY;
+    const distance = Math.hypot(dx, dy);
+    const scale = svgRect.width / 240; // viewBox width
+    const scaledRadius = radius * scale;
+    if (distance > scaledRadius) {
+      setIsRunning(prev => !prev);
+    }
+  };
+
   return (
-    <div className={`mqt-display fullscreen theme-${theme}`} style={{ cursor: 'none' }} onClick={() => setIsRunning(!isRunning)}>
+    <div className={`mqt-display fullscreen theme-${theme}`} style={{ cursor: 'none' }} onClick={handleDisplayClick}>
       <svg className="circle-svg" viewBox="0 0 240 240">
         {/* Clock face background circle - conditionally rendered */}
         {!hideClockBackground && (

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -610,10 +610,11 @@ const MqtDisplay = () => {
     const dayLabelScale = 0.3; // render 'Day' at 30% of main font size
     const dayLabelWidth = unitFactor * 3 * dayLabelScale; // approximate width for 'Day' at scaled size
     const gapFactor = charFactor * 0.2; // small spacing between day digits and 'Day'
+    const afterGapFactor = charFactor * 0.3; // spacing between 'Day' and hours
     if (timeFormat === 'mm') {
       if (isVeryLongDuration) {
         // DDayHH + 'h'
-        widthFactor = charFactor * dayDigits + gapFactor + dayLabelWidth + (2 * charFactor) + unitFactor;
+        widthFactor = charFactor * dayDigits + gapFactor + dayLabelWidth + afterGapFactor + (2 * charFactor) + unitFactor;
       } else if (isLongDuration) {
         // HHMM (no 'm') but with 'h'
         widthFactor = charFactor * (hourDigits + 2) + unitFactor; // hours + 2 minute digits + 'h'
@@ -627,7 +628,7 @@ const MqtDisplay = () => {
     } else if (timeFormat === 'mm:ss') {
       if (isVeryLongDuration) {
         // DDayHH + 'h'
-        widthFactor = charFactor * dayDigits + gapFactor + dayLabelWidth + (2 * charFactor) + unitFactor;
+        widthFactor = charFactor * dayDigits + gapFactor + dayLabelWidth + afterGapFactor + (2 * charFactor) + unitFactor;
       } else if (isLongDuration) {
         // HH:MM (no 'm') but with 'h' and colon
         widthFactor = charFactor * (hourDigits + 2) + unitFactor + colonFactor;
@@ -936,7 +937,8 @@ const MqtDisplay = () => {
           const dayLabelScale = 0.3;
           const dayLabelWidth = unitWidth * dayLabel.length * dayLabelScale;
           const gapWidth = charWidth * 0.2; // small gap between day digits and 'Day'
-          const totalWidth = (dayStr.length * charWidth) + gapWidth + dayLabelWidth + (2 * charWidth) + unitWidth; // D + gap + 'Day' + HH + 'h'
+          const afterDayGap = charWidth * 0.3; // gap between 'Day' and hours
+          const totalWidth = (dayStr.length * charWidth) + gapWidth + dayLabelWidth + afterDayGap + (2 * charWidth) + unitWidth; // D + gap + 'Day' + gap + HH + 'h'
           const startX = 120 - totalWidth / 2;
 
           // Render day digits
@@ -996,7 +998,7 @@ const MqtDisplay = () => {
           );
 
           // Hours within the day (two digits)
-          const hoursStart = dayX + (dayLabelWidth / 2);
+          const hoursStart = dayX + (dayLabelWidth / 2) + afterDayGap;
           for (let i = 0; i < 2; i++) {
             const digitX = hoursStart + (i * charWidth) + (charWidth / 2);
             elements.push(
@@ -1322,7 +1324,8 @@ const MqtDisplay = () => {
           const dayLabelScale = 0.3;
           const dayLabelWidth = unitWidth * dayLabel.length * dayLabelScale;
           const gapWidth = charWidth * 0.2; // small gap between day digits and 'Day'
-          const totalWidth = (dayStr.length * charWidth) + gapWidth + dayLabelWidth + (2 * charWidth) + unitWidth;
+          const afterDayGap = charWidth * 0.3; // gap between 'Day' and hours
+          const totalWidth = (dayStr.length * charWidth) + gapWidth + dayLabelWidth + afterDayGap + (2 * charWidth) + unitWidth;
           const startX = 120 - totalWidth / 2;
 
           // Days
@@ -1382,7 +1385,7 @@ const MqtDisplay = () => {
           );
 
           // Hours within day (two digits)
-          const hoursStart = dayX + (dayLabelWidth / 2);
+          const hoursStart = dayX + (dayLabelWidth / 2) + afterDayGap;
           for (let i = 0; i < 2; i++) {
             const digitX = hoursStart + (i * charWidth) + (charWidth / 2);
             elements.push(

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -767,6 +767,15 @@ const MqtDisplay = () => {
         if (digitPosition >= numDigits) break;
         const placeValue = Math.pow(10, numDigits - 1 - digitPosition);
 
+        // Snap to HH:00 when decreasing any hour digit while minutes > 0
+        if (!isIncrement && minutesWithinHour > 0) {
+          let newTotalMinutes = hours * 60; // drop minutes within the hour to 00
+          if (newTotalMinutes < 0) newTotalMinutes = 0;
+          if (newTotalMinutes > 999) newTotalMinutes = 999;
+          newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
+          break;
+        }
+
         let newHours = isIncrement ? hours + placeValue : hours - placeValue;
         if (newHours < 0) newHours = 0;
         let newTotalMinutes = newHours * 60 + minutesWithinHour;

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -94,6 +94,7 @@ const MqtDisplay = () => {
     }
   };
 
+  const MAX_MINUTES = 43200; // 30 days
   const radius = 110; // Enlarged radius to provide more space for expanding timer text
   const circumference = 2 * Math.PI * radius;
 
@@ -681,8 +682,8 @@ const MqtDisplay = () => {
           currentTotalMinutes + placeValue :
           currentTotalMinutes - placeValue;
 
-        // Limit to 999 minutes max, minimum 1 minute
-        newTotalMinutes = Math.min(999, Math.max(1, newTotalMinutes));
+        // Limit to MAX_MINUTES minutes max, minimum 1 minute
+        newTotalMinutes = Math.min(MAX_MINUTES, Math.max(1, newTotalMinutes));
 
         // Convert back to seconds for timer duration
         newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
@@ -706,8 +707,8 @@ const MqtDisplay = () => {
           currentMinutesTotal + minutePlaceValue :
           currentMinutesTotal - minutePlaceValue;
 
-        // Limit to 999 minutes max, minimum 1 minute for MM:SS format
-        newMinutesTotal = Math.min(999, Math.max(1, newMinutesTotal));
+        // Limit to MAX_MINUTES minutes max, minimum 1 minute for MM:SS format
+        newMinutesTotal = Math.min(MAX_MINUTES, Math.max(1, newMinutesTotal));
 
         // Preserve current seconds and update total duration
         const currentSeconds = totalSeconds % 60;
@@ -748,10 +749,10 @@ const MqtDisplay = () => {
           updatedMinutes = 1;
           newSeconds = 0;
         }
-        // Ensure maximum 999 minute total
-        else if (updatedMinutes > 999) {
-          updatedMinutes = 999;
-          newSeconds = 59; // Cap at 999:59
+        // Ensure maximum MAX_MINUTES minute total
+        else if (updatedMinutes > MAX_MINUTES) {
+          updatedMinutes = MAX_MINUTES;
+          newSeconds = 59; // Cap at MAX_MINUTES:59
         }
 
         // Update duration with new minutes and seconds
@@ -772,7 +773,7 @@ const MqtDisplay = () => {
         if (!isIncrement && minutesWithinHour > 0) {
           let newTotalMinutes = hours * 60; // drop minutes within the hour to 00
           if (newTotalMinutes < 0) newTotalMinutes = 0;
-          if (newTotalMinutes > 999) newTotalMinutes = 999;
+          if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES;
           newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
           break;
         }
@@ -781,7 +782,7 @@ const MqtDisplay = () => {
         if (newHours < 0) newHours = 0;
         let newTotalMinutes = newHours * 60 + minutesWithinHour;
         if (newTotalMinutes < 0) newTotalMinutes = 0; // allow zero so it can switch below 60 correctly
-        if (newTotalMinutes > 999) newTotalMinutes = 999; // cap consistent with other formats
+        if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES; // cap consistent with other formats
         newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
         break;
       }
@@ -810,7 +811,7 @@ const MqtDisplay = () => {
 
         let newTotalMinutes = newHours * 60 + newMinutes;
         if (newTotalMinutes < 0) newTotalMinutes = 0; // allow zero
-        if (newTotalMinutes > 999) newTotalMinutes = 999;
+        if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES;
         newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
         break;
       }

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -581,12 +581,13 @@ const MqtDisplay = () => {
       baseSize = 60; // Original size for short text
     }
 
-    const baseComputed = Math.round(baseSize * scaleFactor * 1.3);
+    const scaleBoost = hideClockBackground ? 1.5 : 1.3;
+    const baseComputed = Math.round(baseSize * scaleFactor * scaleBoost);
 
     // Constrain font size to fit within the circle and background
     const baseStrokeWidth = circleStyle === 'fat' ? 16 : circleStyle === 'bw' ? 2 : 8;
     const strokeW = getResponsiveStrokeWidth(baseStrokeWidth);
-    const padding = 10 + (hideClockBackground ? 0 : 4);
+    const padding = hideClockBackground ? 6 : 14;
     const innerDiameter = 2 * (radius - strokeW / 2 - padding);
     const heightMax = innerDiameter * 0.9;
 

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -1082,8 +1082,9 @@ const MqtDisplay = () => {
       case 'mm:ss': {
         if (isLongDuration) {
           // Switch to HH:MM when total duration exceeds threshold
-          const hours = Math.floor(currentDuration / 3600);
-          const minutesInHour = Math.floor((currentDuration % 3600) / 60);
+          const totalForDisplay = countUp ? Math.max(0, time) : Math.max(0, time);
+          const hours = Math.floor(totalForDisplay / 3600);
+          const minutesInHour = Math.floor((totalForDisplay % 3600) / 60);
           const hourStr = String(hours);
           const minuteStr = String(minutesInHour).padStart(2, '0');
 

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -777,26 +777,19 @@ const MqtDisplay = () => {
       case 'hours': {
         const hours = Math.floor(totalSeconds / 3600);
         const minutesWithinHour = Math.floor((totalSeconds % 3600) / 60);
+        const secondsWithinMinute = totalSeconds % 60;
         const hourStr = String(hours);
         const numDigits = hourStr.length || 1;
         if (digitPosition >= numDigits) break;
         const placeValue = Math.pow(10, numDigits - 1 - digitPosition);
 
-        // Snap to HH:00 when decreasing any hour digit while minutes > 0
-        if (!isIncrement && minutesWithinHour > 0) {
-          let newTotalMinutes = hours * 60; // drop minutes within the hour to 00
-          if (newTotalMinutes < 0) newTotalMinutes = 0;
-          if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES;
-          newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
-          break;
-        }
-
         let newHours = isIncrement ? hours + placeValue : hours - placeValue;
         if (newHours < 0) newHours = 0;
+
         let newTotalMinutes = newHours * 60 + minutesWithinHour;
-        if (newTotalMinutes < 0) newTotalMinutes = 0; // allow zero so it can switch below 60 correctly
-        if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES; // cap consistent with other formats
-        newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
+        if (newTotalMinutes < 0) newTotalMinutes = 0;
+        if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES;
+        newDuration = newTotalMinutes * 60 + secondsWithinMinute;
         break;
       }
 

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -607,7 +607,8 @@ const MqtDisplay = () => {
     let widthFactor;
     const daysTotal = Math.floor(totalForDisplay / 86400);
     const dayDigits = String(daysTotal).length || 1;
-    const dayLabelWidth = unitFactor * 3; // 'Day'
+    const dayLabelScale = 0.1; // render 'Day' at 10% of main font size
+    const dayLabelWidth = unitFactor * 3 * dayLabelScale; // approximate width for 'Day' at scaled size
     if (timeFormat === 'mm') {
       if (isVeryLongDuration) {
         // DDayHH + 'h'
@@ -931,7 +932,8 @@ const MqtDisplay = () => {
           const hourStr = String(hoursInDay).padStart(2, '0');
 
           const dayLabel = 'Day';
-          const dayLabelWidth = unitWidth * dayLabel.length;
+          const dayLabelScale = 0.1;
+          const dayLabelWidth = unitWidth * dayLabel.length * dayLabelScale;
           const totalWidth = (dayStr.length * charWidth) + dayLabelWidth + (2 * charWidth) + unitWidth; // D + 'Day' + HH + 'h'
           const startX = 120 - totalWidth / 2;
 
@@ -984,7 +986,7 @@ const MqtDisplay = () => {
               y={125}
               textAnchor="middle"
               fontFamily={font}
-              fontSize={fontSize}
+              fontSize={fontSize * dayLabelScale}
               fill={dynamicTextColor}
             >
               {dayLabel}
@@ -1315,7 +1317,8 @@ const MqtDisplay = () => {
           const hourStr = String(hoursInDay).padStart(2, '0');
 
           const dayLabel = 'Day';
-          const dayLabelWidth = unitWidth * dayLabel.length;
+          const dayLabelScale = 0.1;
+          const dayLabelWidth = unitWidth * dayLabel.length * dayLabelScale;
           const totalWidth = (dayStr.length * charWidth) + dayLabelWidth + (2 * charWidth) + unitWidth;
           const startX = 120 - totalWidth / 2;
 
@@ -1368,7 +1371,7 @@ const MqtDisplay = () => {
               y={125}
               textAnchor="middle"
               fontFamily={font}
-              fontSize={fontSize}
+              fontSize={fontSize * dayLabelScale}
               fill={dynamicTextColor}
             >
               Day

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -827,17 +827,28 @@ const MqtDisplay = () => {
         const days = Math.floor(totalSeconds / 86400);
         const hoursWithinDay = Math.floor((totalSeconds % 86400) / 3600);
         const minutesWithinHour = Math.floor((totalSeconds % 3600) / 60);
+        const secondsWithinMinute = totalSeconds % 60;
         const dayStr = String(days);
         const numDigits = dayStr.length || 1;
         if (digitPosition >= numDigits) break;
         const placeValue = Math.pow(10, numDigits - 1 - digitPosition);
+
+        // Special-case borrow: when decreasing at 1 Day and hour is 00, fallback to 23h preserving minutes/seconds
+        if (!isIncrement && placeValue === 1 && days >= 1 && hoursWithinDay === 0) {
+          const newDaysBorrow = Math.max(0, days - 1);
+          let borrowTotalMinutes = newDaysBorrow * 24 * 60 + 23 * 60 + minutesWithinHour;
+          if (borrowTotalMinutes < 0) borrowTotalMinutes = 0;
+          if (borrowTotalMinutes > MAX_MINUTES) borrowTotalMinutes = MAX_MINUTES;
+          newDuration = borrowTotalMinutes * 60 + secondsWithinMinute;
+          break;
+        }
 
         let newDays = isIncrement ? days + placeValue : days - placeValue;
         if (newDays < 0) newDays = 0;
         let newTotalMinutes = newDays * 24 * 60 + hoursWithinDay * 60 + minutesWithinHour;
         if (newTotalMinutes < 0) newTotalMinutes = 0;
         if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES;
-        newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
+        newDuration = newTotalMinutes * 60 + secondsWithinMinute;
         break;
       }
 

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -483,9 +483,9 @@ const MqtDisplay = () => {
     }
   };
 
-  // Determine if we should switch to hour-inclusive display based on current time value
+  // Determine if we should switch to hour-inclusive display when current time exceeds 120 minutes
   const currentTotalSeconds = Math.max(0, safeTime);
-  const isLongDuration = Math.floor(currentTotalSeconds / 60) >= 60;
+  const isLongDuration = Math.floor(currentTotalSeconds / 60) > 120;
 
   // Dynamic font size based on actual digit count and screen size
   const getDynamicFontSize = () => {

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -690,12 +690,22 @@ const MqtDisplay = () => {
         // Position 0 = leftmost digit (highest value), Position 1 = next digit, etc.
         const placeValue = Math.pow(10, numDigits - 1 - digitPosition);
 
-        // Add or subtract the place value (proper carry-over: 9 → 10, not 9 → 0)
-        let newTotalMinutes = isIncrement ?
-          currentTotalMinutes + placeValue :
-          currentTotalMinutes - placeValue;
+        // Add or subtract the place value with borrow-aware decrement
+        let newTotalMinutes;
+        if (isIncrement) {
+          newTotalMinutes = currentTotalMinutes + placeValue;
+        } else {
+          const candidate = currentTotalMinutes - placeValue;
+          if (candidate <= 0) {
+            // If decrement crosses digit boundary (e.g., 100 -> 0), fallback to max of lower digit range (e.g., 99)
+            const fallback = numDigits > 1 ? Math.pow(10, numDigits - 1) - 1 : 1;
+            newTotalMinutes = fallback;
+          } else {
+            newTotalMinutes = candidate;
+          }
+        }
 
-        // Limit to MAX_MINUTES minutes max, minimum 1 minute
+        // Clamp to bounds
         newTotalMinutes = Math.min(MAX_MINUTES, Math.max(1, newTotalMinutes));
 
         // Convert back to seconds for timer duration
@@ -715,12 +725,21 @@ const MqtDisplay = () => {
         // Calculate place value for proper carry-over (same logic as totalMinutes)
         const minutePlaceValue = Math.pow(10, numMinuteDigits - 1 - digitPosition);
 
-        // Add or subtract place value (9:59 → 10:59 when clicking top of "9")
-        let newMinutesTotal = isIncrement ?
-          currentMinutesTotal + minutePlaceValue :
-          currentMinutesTotal - minutePlaceValue;
+        // Add or subtract place value with borrow-aware decrement
+        let newMinutesTotal;
+        if (isIncrement) {
+          newMinutesTotal = currentMinutesTotal + minutePlaceValue;
+        } else {
+          const candidate = currentMinutesTotal - minutePlaceValue;
+          if (candidate <= 0) {
+            const fallback = numMinuteDigits > 1 ? Math.pow(10, numMinuteDigits - 1) - 1 : 1;
+            newMinutesTotal = fallback;
+          } else {
+            newMinutesTotal = candidate;
+          }
+        }
 
-        // Limit to MAX_MINUTES minutes max, minimum 1 minute for MM:SS format
+        // Clamp within bounds for MM:SS
         newMinutesTotal = Math.min(MAX_MINUTES, Math.max(1, newMinutesTotal));
 
         // Preserve current seconds and update total duration

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -487,6 +487,7 @@ const MqtDisplay = () => {
   // Determine if we should switch to hour-inclusive display when current time exceeds 120 minutes
   const currentTotalSeconds = Math.max(0, safeTime);
   const isLongDuration = Math.floor(currentTotalSeconds / 60) > 120;
+  const isVeryLongDuration = Math.floor(currentTotalSeconds / 60) >= 1440;
 
   // Dynamic font size based on actual digit count and screen size
   const getDynamicFontSize = () => {
@@ -604,8 +605,14 @@ const MqtDisplay = () => {
     const minuteDigits = String(minutesTotal).length || 1;
 
     let widthFactor;
+    const daysTotal = Math.floor(totalForDisplay / 86400);
+    const dayDigits = String(daysTotal).length || 1;
+    const dayLabelWidth = unitWidth * 3; // 'Day'
     if (timeFormat === 'mm') {
-      if (isLongDuration) {
+      if (isVeryLongDuration) {
+        // DDayHH + 'h'
+        widthFactor = charFactor * dayDigits + dayLabelWidth + (2 * charFactor) + unitFactor;
+      } else if (isLongDuration) {
         // HHMM (no 'm') but with 'h'
         widthFactor = charFactor * (hourDigits + 2) + unitFactor; // hours + 2 minute digits + 'h'
       } else if ((countUp ? time : Math.max(0, time)) < 60) {
@@ -616,7 +623,10 @@ const MqtDisplay = () => {
         widthFactor = charFactor * minuteDigits;
       }
     } else if (timeFormat === 'mm:ss') {
-      if (isLongDuration) {
+      if (isVeryLongDuration) {
+        // DDayHH + 'h'
+        widthFactor = charFactor * dayDigits + dayLabelWidth + (2 * charFactor) + unitFactor;
+      } else if (isLongDuration) {
         // HH:MM (no 'm') but with 'h' and colon
         widthFactor = charFactor * (hourDigits + 2) + unitFactor + colonFactor;
       } else {
@@ -816,6 +826,55 @@ const MqtDisplay = () => {
         break;
       }
 
+      // DAYS for DDayHH (when >24h)
+      case 'days': {
+        const days = Math.floor(totalSeconds / 86400);
+        const hoursWithinDay = Math.floor((totalSeconds % 86400) / 3600);
+        const minutesWithinHour = Math.floor((totalSeconds % 3600) / 60);
+        const dayStr = String(days);
+        const numDigits = dayStr.length || 1;
+        if (digitPosition >= numDigits) break;
+        const placeValue = Math.pow(10, numDigits - 1 - digitPosition);
+
+        let newDays = isIncrement ? days + placeValue : days - placeValue;
+        if (newDays < 0) newDays = 0;
+        let newTotalMinutes = newDays * 24 * 60 + hoursWithinDay * 60 + minutesWithinHour;
+        if (newTotalMinutes < 0) newTotalMinutes = 0;
+        if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES;
+        newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
+        break;
+      }
+
+      // HOURS within day for DDayHH (two digits 00-23 with carry to days)
+      case 'hoursWithinDay': {
+        const days = Math.floor(totalSeconds / 86400);
+        const hoursInDay = Math.floor((totalSeconds % 86400) / 3600);
+        const minutesWithinHour = Math.floor((totalSeconds % 3600) / 60);
+        const placeValue = digitPosition === 0 ? 10 : 1; // tens or ones
+
+        let newHours = isIncrement ? hoursInDay + placeValue : hoursInDay - placeValue;
+        let newDays = days;
+
+        if (newHours >= 24) {
+          const carryDays = Math.floor(newHours / 24);
+          newHours = newHours % 24;
+          newDays = Math.max(0, newDays + carryDays);
+        } else if (newHours < 0) {
+          const borrowDays = -Math.ceil((-newHours) / 24);
+          newDays = Math.max(0, newDays + borrowDays);
+          newHours = newHours - borrowDays * 24; // bring back to 0..23
+          if (newDays === 0 && newHours < 0) {
+            newHours = 0;
+          }
+        }
+
+        let newTotalMinutes = newDays * 24 * 60 + newHours * 60 + minutesWithinHour;
+        if (newTotalMinutes < 0) newTotalMinutes = 0;
+        if (newTotalMinutes > MAX_MINUTES) newTotalMinutes = MAX_MINUTES;
+        newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
+        break;
+      }
+
       default:
         // No action for unknown digit types
         break;
@@ -863,8 +922,133 @@ const MqtDisplay = () => {
       case 'mm': {
         const totalTime = countUp ? time : Math.max(0, time);
 
-        // If duration is configured as "long", switch to HHMM
-        if (isLongDuration) {
+        // If duration is configured as "long", switch to HHMM (or DDayHH when >24h)
+        if (isVeryLongDuration) {
+          const totalForDisplay = countUp ? Math.max(0, time) : Math.max(0, time);
+          const days = Math.floor(totalForDisplay / 86400);
+          const hoursInDay = Math.floor((totalForDisplay % 86400) / 3600);
+          const dayStr = String(days);
+          const hourStr = String(hoursInDay).padStart(2, '0');
+
+          const dayLabel = 'Day';
+          const dayLabelWidth = unitWidth * dayLabel.length;
+          const totalWidth = (dayStr.length * charWidth) + dayLabelWidth + (2 * charWidth) + unitWidth; // D + 'Day' + HH + 'h'
+          const startX = 120 - totalWidth / 2;
+
+          // Render day digits
+          for (let i = 0; i < dayStr.length; i++) {
+            const digitX = startX + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`days-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('days', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('days', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`days-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {dayStr[i]}
+                </text>
+              </g>
+            );
+          }
+
+          // 'Day' label
+          const dayX = startX + (dayStr.length * charWidth) + (dayLabelWidth / 2);
+          elements.push(
+            <text
+              key="unit-day"
+              x={dayX}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              {dayLabel}
+            </text>
+          );
+
+          // Hours within the day (two digits)
+          const hoursStart = dayX + (dayLabelWidth / 2);
+          for (let i = 0; i < 2; i++) {
+            const digitX = hoursStart + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`hwd-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('hoursWithinDay', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('hoursWithinDay', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`hoursWithinDay-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {hourStr[i]}
+                </text>
+              </g>
+            );
+          }
+
+          // 'h' unit after hours
+          const hX2 = hoursStart + (2 * charWidth) + (unitWidth / 2);
+          elements.push(
+            <text
+              key="unit-h-dday"
+              x={hX2}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              h
+            </text>
+          );
+
+        } else if (isLongDuration) {
           const totalForDisplay = countUp ? Math.max(0, time) : Math.max(0, time);
           const hours = Math.floor(totalForDisplay / 3600);
           const minutesInHour = Math.floor((totalForDisplay % 3600) / 60);
@@ -1123,7 +1307,132 @@ const MqtDisplay = () => {
 
       // MM:SS FORMAT: Unlimited minutes + traditional seconds (0-59)
       case 'mm:ss': {
-        if (isLongDuration) {
+        if (isVeryLongDuration) {
+          const totalForDisplay = countUp ? Math.max(0, time) : Math.max(0, time);
+          const days = Math.floor(totalForDisplay / 86400);
+          const hoursInDay = Math.floor((totalForDisplay % 86400) / 3600);
+          const dayStr = String(days);
+          const hourStr = String(hoursInDay).padStart(2, '0');
+
+          const dayLabel = 'Day';
+          const dayLabelWidth = unitWidth * dayLabel.length;
+          const totalWidth = (dayStr.length * charWidth) + dayLabelWidth + (2 * charWidth) + unitWidth;
+          const startX = 120 - totalWidth / 2;
+
+          // Days
+          for (let i = 0; i < dayStr.length; i++) {
+            const digitX = startX + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`days-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('days', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('days', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`days-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {dayStr[i]}
+                </text>
+              </g>
+            );
+          }
+
+          // 'Day'
+          const dayX = startX + (dayStr.length * charWidth) + (dayLabelWidth / 2);
+          elements.push(
+            <text
+              key="unit-day"
+              x={dayX}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              Day
+            </text>
+          );
+
+          // Hours within day (two digits)
+          const hoursStart = dayX + (dayLabelWidth / 2);
+          for (let i = 0; i < 2; i++) {
+            const digitX = hoursStart + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`hwd-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('hoursWithinDay', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('hoursWithinDay', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`hoursWithinDay-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {hourStr[i]}
+                </text>
+              </g>
+            );
+          }
+
+          // 'h'
+          const hX2 = hoursStart + (2 * charWidth) + (unitWidth / 2);
+          elements.push(
+            <text
+              key="unit-h-dday"
+              x={hX2}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              h
+            </text>
+          );
+
+        } else if (isLongDuration) {
           // Switch to HH:MM when total duration exceeds threshold
           const totalForDisplay = countUp ? Math.max(0, time) : Math.max(0, time);
           const hours = Math.floor(totalForDisplay / 3600);

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -607,7 +607,7 @@ const MqtDisplay = () => {
     let widthFactor;
     const daysTotal = Math.floor(totalForDisplay / 86400);
     const dayDigits = String(daysTotal).length || 1;
-    const dayLabelScale = 0.1; // render 'Day' at 10% of main font size
+    const dayLabelScale = 0.3; // render 'Day' at 30% of main font size
     const dayLabelWidth = unitFactor * 3 * dayLabelScale; // approximate width for 'Day' at scaled size
     if (timeFormat === 'mm') {
       if (isVeryLongDuration) {
@@ -932,7 +932,7 @@ const MqtDisplay = () => {
           const hourStr = String(hoursInDay).padStart(2, '0');
 
           const dayLabel = 'Day';
-          const dayLabelScale = 0.1;
+          const dayLabelScale = 0.3;
           const dayLabelWidth = unitWidth * dayLabel.length * dayLabelScale;
           const totalWidth = (dayStr.length * charWidth) + dayLabelWidth + (2 * charWidth) + unitWidth; // D + 'Day' + HH + 'h'
           const startX = 120 - totalWidth / 2;
@@ -1043,7 +1043,7 @@ const MqtDisplay = () => {
               y={125}
               textAnchor="middle"
               fontFamily={font}
-              fontSize={fontSize}
+              fontSize={fontSize * 0.3}
               fill={dynamicTextColor}
             >
               h
@@ -1109,7 +1109,7 @@ const MqtDisplay = () => {
               y={125}
               textAnchor="middle"
               fontFamily={font}
-              fontSize={fontSize}
+              fontSize={fontSize * 0.3}
               fill={dynamicTextColor}
             >
               h
@@ -1317,7 +1317,7 @@ const MqtDisplay = () => {
           const hourStr = String(hoursInDay).padStart(2, '0');
 
           const dayLabel = 'Day';
-          const dayLabelScale = 0.1;
+          const dayLabelScale = 0.3;
           const dayLabelWidth = unitWidth * dayLabel.length * dayLabelScale;
           const totalWidth = (dayStr.length * charWidth) + dayLabelWidth + (2 * charWidth) + unitWidth;
           const startX = 120 - totalWidth / 2;
@@ -1428,7 +1428,7 @@ const MqtDisplay = () => {
               y={125}
               textAnchor="middle"
               fontFamily={font}
-              fontSize={fontSize}
+              fontSize={fontSize * 0.3}
               fill={dynamicTextColor}
             >
               h
@@ -1496,7 +1496,7 @@ const MqtDisplay = () => {
               y={125}
               textAnchor="middle"
               fontFamily={font}
-              fontSize={fontSize}
+              fontSize={fontSize * 0.3}
               fill={dynamicTextColor}
             >
               h

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -424,7 +424,7 @@ const MqtDisplay = () => {
   let percent;
 
   // Auto-switch to second progress when ≤10 seconds remain (regardless of setting)
-  const timeRemaining = countUp ? safeDuration - safeTime : safeTime;
+  const timeRemaining = countUp ? safeDuration - safeSmoothTime : safeSmoothTime;
   const useSecondProgress = timeRemaining <= 10;
 
   if (useSecondProgress) {

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -461,8 +461,8 @@ const MqtDisplay = () => {
 
   // Time format
   const formatTime = () => {
-    const safeTime = isNaN(time) ? 0 : time;
-    const total = countUp ? safeTime : Math.max(0, safeTime);
+    const safeTimeLocal = isNaN(time) ? 0 : time;
+    const total = countUp ? safeTimeLocal : Math.max(0, safeTimeLocal);
     const s = total % 60;
 
     // Ensure s is a valid number
@@ -482,6 +482,9 @@ const MqtDisplay = () => {
         return `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(safeS).padStart(2, '0')}`;
     }
   };
+
+  // Determine if we should switch to hour-inclusive display (based on total duration setting)
+  const isLongDuration = Math.floor(safeDuration / 60) > 56;
 
   // Dynamic font size based on actual digit count and screen size
   const getDynamicFontSize = () => {
@@ -512,7 +515,7 @@ const MqtDisplay = () => {
       const totalTime = countUp ? time : Math.max(0, time);
 
       // Check if we're in SS mode (last minute)
-      if (totalTime < 60) {
+      if (totalTime < 60 && !isLongDuration) {
         // SS mode: showing seconds (1-2 digits)
         const secondsStr = String(Math.floor(totalTime % 60));
         const actualDigits = secondsStr.length;
@@ -522,6 +525,14 @@ const MqtDisplay = () => {
         } else {
           baseSize = 68; // Two digit seconds
         }
+      } else if (isLongDuration) {
+        // HHMM mode sizing depending on hour digits
+        const hours = Math.floor(safeDuration / 3600);
+        const hourDigits = String(hours).length || 1;
+        if (hourDigits === 1) baseSize = 58; // e.g., 1h00m
+        else if (hourDigits === 2) baseSize = 50;
+        else if (hourDigits === 3) baseSize = 42;
+        else baseSize = 35;
       } else {
         // MM mode: showing minutes (1, 2, 3, 4+ digits)
         const totalMinutes = Math.floor(totalTime / 60);
@@ -538,18 +549,28 @@ const MqtDisplay = () => {
         }
       }
     } else if (timeFormat === 'mm:ss') {
-      // For MM:SS format, consider minute digits + colon + seconds
-      const totalMinutes = Math.floor((countUp ? time : Math.max(0, time)) / 60);
-      const minuteDigits = String(totalMinutes).length;
-
-      if (minuteDigits === 1) {
-        baseSize = 58; // 1:XX format
-      } else if (minuteDigits === 2) {
-        baseSize = 50; // 12:XX format
-      } else if (minuteDigits === 3) {
-        baseSize = 42; // 123:XX format
+      if (isLongDuration) {
+        // HH:MM mode sizing depending on hour digits
+        const hours = Math.floor(safeDuration / 3600);
+        const hourDigits = String(hours).length || 1;
+        if (hourDigits === 1) baseSize = 58; // 1h:00m
+        else if (hourDigits === 2) baseSize = 50;
+        else if (hourDigits === 3) baseSize = 42;
+        else baseSize = 35;
       } else {
-        baseSize = 35; // 1234:XX+ format
+        // For MM:SS format, consider minute digits + colon + seconds
+        const totalMinutes = Math.floor((countUp ? time : Math.max(0, time)) / 60);
+        const minuteDigits = String(totalMinutes).length;
+
+        if (minuteDigits === 1) {
+          baseSize = 58; // 1:XX format
+        } else if (minuteDigits === 2) {
+          baseSize = 50; // 12:XX format
+        } else if (minuteDigits === 3) {
+          baseSize = 42; // 123:XX format
+        } else {
+          baseSize = 35; // 1234:XX+ format
+        }
       }
     } else if (timeFormat === 'hh:mm:ss' || (timeFormat === 'hhmmss' && textLength > 6)) {
       baseSize = 36; // Smaller for longer text
@@ -564,8 +585,8 @@ const MqtDisplay = () => {
 
   // Digit clicking functions
   const getTimeComponents = () => {
-    const safeTime = isNaN(time) ? 0 : time;
-    const total = countUp ? safeTime : Math.max(0, safeTime);
+    const safeTimeLocal = isNaN(time) ? 0 : time;
+    const total = countUp ? safeTimeLocal : Math.max(0, safeTimeLocal);
     const h = Math.floor(total / 3600);
     const m = Math.floor((total % 3600) / 60);
     const s = total % 60;
@@ -582,7 +603,7 @@ const MqtDisplay = () => {
    * CORE DIGIT CLICKING FUNCTION
    * Handles increment/decrement of individual timer digits when clicked
    *
-   * @param {string} digitType - Type of digit ('totalMinutes', 'minutes', 'seconds', 'hours')
+   * @param {string} digitType - Type of digit ('totalMinutes', 'minutes', 'seconds', 'hours', 'minutesWithinHour')
    * @param {number} digitPosition - Position of digit (0 = leftmost/highest place value)
    * @param {boolean} isIncrement - True for increment (top half click), false for decrement (bottom half)
    */
@@ -592,7 +613,7 @@ const MqtDisplay = () => {
 
     switch (digitType) {
       // MM FORMAT: Unlimited minutes (1, 10, 100, 999+)
-      case 'totalMinutes':
+      case 'totalMinutes': {
         const currentTotalMinutes = Math.floor(totalSeconds / 60);
         const totalMinuteStr = String(currentTotalMinutes);
         const numDigits = totalMinuteStr.length;
@@ -613,12 +634,12 @@ const MqtDisplay = () => {
         newTotalMinutes = Math.min(999, Math.max(1, newTotalMinutes));
 
         // Convert back to seconds for timer duration
-        newDuration = newTotalMinutes * 60;
+        newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
         break;
-
+      }
 
       // MM:SS FORMAT: Minutes part behaves like totalMinutes (unlimited)
-      case 'minutes':
+      case 'minutes': {
         const currentMinutesTotal = Math.floor(totalSeconds / 60);
         const minutesStr = String(currentMinutesTotal);
         const numMinuteDigits = minutesStr.length;
@@ -641,9 +662,10 @@ const MqtDisplay = () => {
         const currentSeconds = totalSeconds % 60;
         newDuration = newMinutesTotal * 60 + currentSeconds;
         break;
+      }
 
       // SECONDS FORMAT: Traditional 0-59 seconds with proper minute carry-over
-      case 'seconds':
+      case 'seconds': {
         // Simple place value: position 0 = tens (10), position 1 = ones (1)
         const secondPlaceValue = digitPosition === 0 ? 10 : 1;
 
@@ -684,6 +706,59 @@ const MqtDisplay = () => {
         // Update duration with new minutes and seconds
         newDuration = updatedMinutes * 60 + newSeconds;
         break;
+      }
+
+      // HOURS DIGITS for HHMM / HH:MM
+      case 'hours': {
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutesWithinHour = Math.floor((totalSeconds % 3600) / 60);
+        const hourStr = String(hours);
+        const numDigits = hourStr.length || 1;
+        if (digitPosition >= numDigits) break;
+        const placeValue = Math.pow(10, numDigits - 1 - digitPosition);
+
+        let newHours = isIncrement ? hours + placeValue : hours - placeValue;
+        if (newHours < 0) newHours = 0;
+        let newTotalMinutes = newHours * 60 + minutesWithinHour;
+        if (newTotalMinutes < 1) newTotalMinutes = 1; // minimum 1 minute
+        if (newTotalMinutes > 999) newTotalMinutes = 999; // cap consistent with other formats
+        newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
+        break;
+      }
+
+      // MINUTES within hour for HHMM / HH:MM (two digits 00-59 with carry to hours)
+      case 'minutesWithinHour': {
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutesWithinHour = Math.floor((totalSeconds % 3600) / 60);
+        const placeValue = digitPosition === 0 ? 10 : 1; // tens or ones
+
+        let newMinutes = isIncrement ? minutesWithinHour + placeValue : minutesWithinHour - placeValue;
+        let carryHours = 0;
+
+        if (newMinutes >= 60) {
+          carryHours = Math.floor(newMinutes / 60);
+          newMinutes = newMinutes % 60;
+        } else if (newMinutes < 0) {
+          carryHours = Math.ceil(newMinutes / 60); // negative
+          newMinutes = ((newMinutes % 60) + 60) % 60;
+        }
+
+        let newHours = hours + carryHours;
+        let newTotalMinutes = newHours * 60 + newMinutes;
+        if (newTotalMinutes < 1) {
+          newTotalMinutes = 1;
+          newHours = 0;
+          newMinutes = 1;
+        }
+        if (newTotalMinutes > 999) {
+          newTotalMinutes = 999;
+          newHours = Math.floor(999 / 60);
+          newMinutes = 999 % 60;
+        }
+        newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
+        break;
+      }
+
       default:
         // No action for unknown digit types
         break;
@@ -722,16 +797,140 @@ const MqtDisplay = () => {
     // LAYOUT CALCULATIONS
     // Character width approximation for digit spacing (60% of font size)
     const charWidth = fontSize * 0.6;
-    // Colon width for MM:SS format spacing (30% of font size)
+    // Colon/unit width for spacing (30% of font size for colon, 35% for unit letters)
     const colonWidth = fontSize * 0.3;
+    const unitWidth = fontSize * 0.35;
 
     switch (timeFormat) {
-      // MM FORMAT: Unlimited minutes (1, 10, 100, 999+) with auto-switch to SS for last minute
-      case 'mm':
+      // MM FORMAT: Unlimited minutes (1, 10, 100, 999+) with auto-switch
+      case 'mm': {
         const totalTime = countUp ? time : Math.max(0, time);
 
+        // If duration is configured as "long", switch to HHMM
+        if (isLongDuration) {
+          const hours = Math.floor((countUp ? currentDuration : currentDuration) / 3600);
+          const minutesInHour = Math.floor(((countUp ? currentDuration : currentDuration) % 3600) / 60);
+          const hourStr = String(hours);
+          const minuteStr = String(minutesInHour).padStart(2, '0');
+
+          const totalWidth = (hourStr.length * charWidth) + unitWidth + (2 * charWidth) + unitWidth; // H + 'h' + MM + 'm'
+          const startX = 120 - totalWidth / 2;
+
+          // Render hour digits
+          for (let i = 0; i < hourStr.length; i++) {
+            const digitX = startX + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`hours-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('hours', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('hours', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`hours-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {hourStr[i]}
+                </text>
+              </g>
+            );
+          }
+
+          // 'h' unit
+          const hX = startX + (hourStr.length * charWidth) + (unitWidth / 2);
+          elements.push(
+            <text
+              key="unit-h"
+              x={hX}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              h
+            </text>
+          );
+
+          // Minutes within the hour (two digits)
+          const minutesStart = hX + (unitWidth / 2);
+          for (let i = 0; i < 2; i++) {
+            const digitX = minutesStart + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`minwh-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('minutesWithinHour', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('minutesWithinHour', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`minutesWithinHour-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {minuteStr[i]}
+                </text>
+              </g>
+            );
+          }
+
+          // 'm' unit
+          const mX = minutesStart + (2 * charWidth) + (unitWidth / 2);
+          elements.push(
+            <text
+              key="unit-m"
+              x={mX}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              m
+            </text>
+          );
+        }
         // Check if we should switch to SS format (last minute)
-        if (totalTime < 60) {
+        else if (totalTime < 60) {
           // SS MODE: Show seconds directly (59, 58, 57...)
           const currentSeconds = Math.floor(totalTime % 60);
           const secondsStr = String(currentSeconds);
@@ -876,132 +1075,274 @@ const MqtDisplay = () => {
           }
         }
         break;
+      }
 
       // MM:SS FORMAT: Unlimited minutes + traditional seconds (0-59)
-      case 'mm:ss':
-        const { totalSeconds } = getTimeComponents();
+      case 'mm:ss': {
+        if (isLongDuration) {
+          // Switch to HH:MM when total duration exceeds threshold
+          const hours = Math.floor(currentDuration / 3600);
+          const minutesInHour = Math.floor((currentDuration % 3600) / 60);
+          const hourStr = String(hours);
+          const minuteStr = String(minutesInHour).padStart(2, '0');
 
-        // PARSE TIME COMPONENTS
-        const mmssMinutes = Math.floor(totalSeconds / 60);  // Total minutes (unlimited: 1, 50, 999+)
-        const mmssSeconds = totalSeconds % 60;              // Traditional seconds (0-59)
-        const minutesStr = String(mmssMinutes);             // No leading zeros for minutes
-        const secondsStr = String(mmssSeconds).padStart(2, '0'); // Always 2 digits for seconds
-        const numMinuteDigits = minutesStr.length;
+          // width: H + 'h' + ':' + MM + 'm'
+          const totalWidth = (hourStr.length * charWidth) + unitWidth + colonWidth + (2 * charWidth) + unitWidth;
+          const startX = 120 - totalWidth / 2;
 
-        // DYNAMIC LAYOUT CALCULATION
-        // Total width = minutes + colon + seconds (always 2 digits)
-        const totalWidth = (numMinuteDigits * charWidth) + colonWidth + (2 * charWidth);
-        // Center the entire display around x=120
-        const displayStartX = 120 - (totalWidth / 2);
+          // Hours
+          for (let i = 0; i < hourStr.length; i++) {
+            const digitX = startX + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`hours-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('hours', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('hours', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`hours-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {hourStr[i]}
+                </text>
+              </g>
+            );
+          }
 
-        // RENDER MINUTE DIGITS (unlimited, like MM format)
-        for (let i = 0; i < numMinuteDigits; i++) {
-          const digitX = displayStartX + (i * charWidth) + (charWidth / 2);
+          // 'h' unit
+          const hX = startX + (hourStr.length * charWidth) + (unitWidth / 2);
           elements.push(
-            <g key={`min-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
-              {/* Top half - increment minute digit */}
+            <text
+              key="unit-h"
+              x={hX}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              h
+            </text>
+          );
+
+          // Colon
+          const colonX = hX + (unitWidth / 2) + (colonWidth / 2);
+          elements.push(
+            <text
+              key="colon-hhmm"
+              x={colonX}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              :
+            </text>
+          );
+
+          // Minutes within the hour (two digits)
+          const minutesStart = colonX + (colonWidth / 2);
+          for (let i = 0; i < 2; i++) {
+            const digitX = minutesStart + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`minwh-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('minutesWithinHour', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('minutesWithinHour', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`minutesWithinHour-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {minuteStr[i]}
+                </text>
+              </g>
+            );
+          }
+
+          // 'm' unit
+          const mX = minutesStart + (2 * charWidth) + (unitWidth / 2);
+          elements.push(
+            <text
+              key="unit-m"
+              x={mX}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              m
+            </text>
+          );
+        } else {
+          const { totalSeconds } = getTimeComponents();
+
+          // PARSE TIME COMPONENTS
+          const mmssMinutes = Math.floor(totalSeconds / 60);  // Total minutes (unlimited: 1, 50, 999+)
+          const mmssSeconds = totalSeconds % 60;              // Traditional seconds (0-59)
+          const minutesStr = String(mmssMinutes);             // No leading zeros for minutes
+          const secondsStr = String(mmssSeconds).padStart(2, '0'); // Always 2 digits for seconds
+          const numMinuteDigits = minutesStr.length;
+
+          // DYNAMIC LAYOUT CALCULATION
+          // Total width = minutes + colon + seconds (always 2 digits)
+          const totalWidth = (numMinuteDigits * charWidth) + colonWidth + (2 * charWidth);
+          // Center the entire display around x=120
+          const displayStartX = 120 - (totalWidth / 2);
+
+          // RENDER MINUTE DIGITS (unlimited, like MM format)
+          for (let i = 0; i < numMinuteDigits; i++) {
+            const digitX = displayStartX + (i * charWidth) + (charWidth / 2);
+            elements.push(
+              <g key={`min-digit-${i}-group`} onClick={(e) => e.stopPropagation()}>
+                {/* Top half - increment minute digit */}
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125 - fontSize / 2}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('minutes', i, true) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                {/* Bottom half - decrement minute digit */}
+                <rect
+                  x={digitX - charWidth / 2}
+                  y={125}
+                  width={charWidth}
+                  height={fontSize / 2}
+                  fill="transparent"
+                  className="timer-digit-clickable"
+                  onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('minutes', i, false) : undefined}
+                  pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
+                />
+                {/* Minute digit text */}
+                <text
+                  x={digitX}
+                  y={125}
+                  textAnchor="middle"
+                  fontFamily={font}
+                  fontSize={fontSize}
+                  fill={editingDigit?.startsWith(`minutes-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                  pointerEvents="none"
+                >
+                  {minutesStr[i]}
+                </text>
+              </g>
+            );
+          }
+
+          // RENDER COLON SEPARATOR
+          const colonX = displayStartX + (numMinuteDigits * charWidth) + (colonWidth / 2);
+          elements.push(
+            <text
+              key="colon1"
+              x={colonX}
+              y={125}
+              textAnchor="middle"
+              fontFamily={font}
+              fontSize={fontSize}
+              fill={dynamicTextColor}
+            >
+              :
+            </text>
+          );
+
+          // RENDER SECONDS DIGITS (always 2 digits, 0-59 range)
+          const secondsStartX = displayStartX + (numMinuteDigits * charWidth) + colonWidth;
+
+          // Helper function to create seconds digit with consistent pattern
+          const createSecondsDigit = (position, digit, digitIndex) => (
+            <g key={`sec-${position}-group`} onClick={(e) => e.stopPropagation()}>
+              {/* Top half - increment */}
               <rect
-                x={digitX - charWidth / 2}
+                x={secondsStartX + (digitIndex * charWidth)}
                 y={125 - fontSize / 2}
                 width={charWidth}
                 height={fontSize / 2}
                 fill="transparent"
                 className="timer-digit-clickable"
-                onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('minutes', i, true) : undefined}
+                onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('seconds', digitIndex, true) : undefined}
                 pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
               />
-              {/* Bottom half - decrement minute digit */}
+              {/* Bottom half - decrement */}
               <rect
-                x={digitX - charWidth / 2}
+                x={secondsStartX + (digitIndex * charWidth)}
                 y={125}
                 width={charWidth}
                 height={fontSize / 2}
                 fill="transparent"
                 className="timer-digit-clickable"
-                onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('minutes', i, false) : undefined}
+                onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('seconds', digitIndex, false) : undefined}
                 pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
               />
-              {/* Minute digit text */}
+              {/* Digit text */}
               <text
-                x={digitX}
+                x={secondsStartX + (digitIndex * charWidth) + (charWidth / 2)}
                 y={125}
                 textAnchor="middle"
                 fontFamily={font}
                 fontSize={fontSize}
-                fill={editingDigit?.startsWith(`minutes-${i}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
+                fill={editingDigit?.startsWith(`seconds-${digitIndex}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
                 pointerEvents="none"
               >
-                {minutesStr[i]}
+                {digit}
               </text>
             </g>
           );
+
+          // Seconds tens digit (position 0)
+          elements.push(createSecondsDigit('tens', secondsStr[0], 0));
+          // Seconds ones digit (position 1)
+          elements.push(createSecondsDigit('ones', secondsStr[1], 1));
         }
-
-        // RENDER COLON SEPARATOR
-        const colonX = displayStartX + (numMinuteDigits * charWidth) + (colonWidth / 2);
-        elements.push(
-          <text
-            key="colon1"
-            x={colonX}
-            y={125}
-            textAnchor="middle"
-            fontFamily={font}
-            fontSize={fontSize}
-            fill={dynamicTextColor}
-          >
-            :
-          </text>
-        );
-
-        // RENDER SECONDS DIGITS (always 2 digits, 0-59 range)
-        const secondsStartX = displayStartX + (numMinuteDigits * charWidth) + colonWidth;
-
-        // Helper function to create seconds digit with consistent pattern
-        const createSecondsDigit = (position, digit, digitIndex) => (
-          <g key={`sec-${position}-group`} onClick={(e) => e.stopPropagation()}>
-            {/* Top half - increment */}
-            <rect
-              x={secondsStartX + (digitIndex * charWidth)}
-              y={125 - fontSize / 2}
-              width={charWidth}
-              height={fontSize / 2}
-              fill="transparent"
-              className="timer-digit-clickable"
-              onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('seconds', digitIndex, true) : undefined}
-              pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
-            />
-            {/* Bottom half - decrement */}
-            <rect
-              x={secondsStartX + (digitIndex * charWidth)}
-              y={125}
-              width={charWidth}
-              height={fontSize / 2}
-              fill="transparent"
-              className="timer-digit-clickable"
-              onClick={(allowClickableTimer || !isRunning) ? () => adjustDigit('seconds', digitIndex, false) : undefined}
-              pointerEvents={(allowClickableTimer || !isRunning) ? 'auto' : 'none'}
-            />
-            {/* Digit text */}
-            <text
-              x={secondsStartX + (digitIndex * charWidth) + (charWidth / 2)}
-              y={125}
-              textAnchor="middle"
-              fontFamily={font}
-              fontSize={fontSize}
-              fill={editingDigit?.startsWith(`seconds-${digitIndex}`) ? (editingDigit.includes('inc') ? '#4caf50' : '#ff6b6b') : dynamicTextColor}
-              pointerEvents="none"
-            >
-              {digit}
-            </text>
-          </g>
-        );
-
-        // Seconds tens digit (position 0)
-        elements.push(createSecondsDigit('tens', secondsStr[0], 0));
-        // Seconds ones digit (position 1)
-        elements.push(createSecondsDigit('ones', secondsStr[1], 1));
         break;
-
+      }
 
       default:
         // Fallback to formatTime() for unsupported formats

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -609,10 +609,11 @@ const MqtDisplay = () => {
     const dayDigits = String(daysTotal).length || 1;
     const dayLabelScale = 0.3; // render 'Day' at 30% of main font size
     const dayLabelWidth = unitFactor * 3 * dayLabelScale; // approximate width for 'Day' at scaled size
+    const gapFactor = charFactor * 0.2; // small spacing between day digits and 'Day'
     if (timeFormat === 'mm') {
       if (isVeryLongDuration) {
         // DDayHH + 'h'
-        widthFactor = charFactor * dayDigits + dayLabelWidth + (2 * charFactor) + unitFactor;
+        widthFactor = charFactor * dayDigits + gapFactor + dayLabelWidth + (2 * charFactor) + unitFactor;
       } else if (isLongDuration) {
         // HHMM (no 'm') but with 'h'
         widthFactor = charFactor * (hourDigits + 2) + unitFactor; // hours + 2 minute digits + 'h'
@@ -626,7 +627,7 @@ const MqtDisplay = () => {
     } else if (timeFormat === 'mm:ss') {
       if (isVeryLongDuration) {
         // DDayHH + 'h'
-        widthFactor = charFactor * dayDigits + dayLabelWidth + (2 * charFactor) + unitFactor;
+        widthFactor = charFactor * dayDigits + gapFactor + dayLabelWidth + (2 * charFactor) + unitFactor;
       } else if (isLongDuration) {
         // HH:MM (no 'm') but with 'h' and colon
         widthFactor = charFactor * (hourDigits + 2) + unitFactor + colonFactor;
@@ -934,7 +935,8 @@ const MqtDisplay = () => {
           const dayLabel = 'Day';
           const dayLabelScale = 0.3;
           const dayLabelWidth = unitWidth * dayLabel.length * dayLabelScale;
-          const totalWidth = (dayStr.length * charWidth) + dayLabelWidth + (2 * charWidth) + unitWidth; // D + 'Day' + HH + 'h'
+          const gapWidth = charWidth * 0.2; // small gap between day digits and 'Day'
+          const totalWidth = (dayStr.length * charWidth) + gapWidth + dayLabelWidth + (2 * charWidth) + unitWidth; // D + gap + 'Day' + HH + 'h'
           const startX = 120 - totalWidth / 2;
 
           // Render day digits
@@ -978,7 +980,7 @@ const MqtDisplay = () => {
           }
 
           // 'Day' label
-          const dayX = startX + (dayStr.length * charWidth) + (dayLabelWidth / 2);
+          const dayX = startX + (dayStr.length * charWidth) + gapWidth + (dayLabelWidth / 2);
           elements.push(
             <text
               key="unit-day"
@@ -1319,7 +1321,8 @@ const MqtDisplay = () => {
           const dayLabel = 'Day';
           const dayLabelScale = 0.3;
           const dayLabelWidth = unitWidth * dayLabel.length * dayLabelScale;
-          const totalWidth = (dayStr.length * charWidth) + dayLabelWidth + (2 * charWidth) + unitWidth;
+          const gapWidth = charWidth * 0.2; // small gap between day digits and 'Day'
+          const totalWidth = (dayStr.length * charWidth) + gapWidth + dayLabelWidth + (2 * charWidth) + unitWidth;
           const startX = 120 - totalWidth / 2;
 
           // Days
@@ -1363,7 +1366,7 @@ const MqtDisplay = () => {
           }
 
           // 'Day'
-          const dayX = startX + (dayStr.length * charWidth) + (dayLabelWidth / 2);
+          const dayX = startX + (dayStr.length * charWidth) + gapWidth + (dayLabelWidth / 2);
           elements.push(
             <text
               key="unit-day"

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -769,7 +769,7 @@ const MqtDisplay = () => {
         let newHours = isIncrement ? hours + placeValue : hours - placeValue;
         if (newHours < 0) newHours = 0;
         let newTotalMinutes = newHours * 60 + minutesWithinHour;
-        if (newTotalMinutes < 1) newTotalMinutes = 1; // minimum 1 minute
+        if (newTotalMinutes < 0) newTotalMinutes = 0; // allow zero so it can switch below 60 correctly
         if (newTotalMinutes > 999) newTotalMinutes = 999; // cap consistent with other formats
         newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
         break;
@@ -782,28 +782,24 @@ const MqtDisplay = () => {
         const placeValue = digitPosition === 0 ? 10 : 1; // tens or ones
 
         let newMinutes = isIncrement ? minutesWithinHour + placeValue : minutesWithinHour - placeValue;
-        let carryHours = 0;
+        let newHours = hours;
 
         if (newMinutes >= 60) {
-          carryHours = Math.floor(newMinutes / 60);
+          const carryHours = Math.floor(newMinutes / 60);
           newMinutes = newMinutes % 60;
+          newHours = Math.max(0, newHours + carryHours);
         } else if (newMinutes < 0) {
-          carryHours = Math.ceil(newMinutes / 60); // negative
-          newMinutes = ((newMinutes % 60) + 60) % 60;
+          const borrowHours = -Math.ceil((-newMinutes) / 60); // e.g., -1..-59 => -1
+          newHours = Math.max(0, newHours + borrowHours);
+          newMinutes = newMinutes - borrowHours * 60; // bring back into 0..59 range
+          if (newHours === 0 && newMinutes < 0) {
+            newMinutes = 0; // cannot go below 0 total
+          }
         }
 
-        let newHours = hours + carryHours;
         let newTotalMinutes = newHours * 60 + newMinutes;
-        if (newTotalMinutes < 1) {
-          newTotalMinutes = 1;
-          newHours = 0;
-          newMinutes = 1;
-        }
-        if (newTotalMinutes > 999) {
-          newTotalMinutes = 999;
-          newHours = Math.floor(999 / 60);
-          newMinutes = 999 % 60;
-        }
+        if (newTotalMinutes < 0) newTotalMinutes = 0; // allow zero
+        if (newTotalMinutes > 999) newTotalMinutes = 999;
         newDuration = newTotalMinutes * 60 + (totalSeconds % 60);
         break;
       }

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -607,7 +607,7 @@ const MqtDisplay = () => {
     let widthFactor;
     const daysTotal = Math.floor(totalForDisplay / 86400);
     const dayDigits = String(daysTotal).length || 1;
-    const dayLabelWidth = unitWidth * 3; // 'Day'
+    const dayLabelWidth = unitFactor * 3; // 'Day'
     if (timeFormat === 'mm') {
       if (isVeryLongDuration) {
         // DDayHH + 'h'

--- a/src/components/MqtDisplay.js
+++ b/src/components/MqtDisplay.js
@@ -808,8 +808,9 @@ const MqtDisplay = () => {
 
         // If duration is configured as "long", switch to HHMM
         if (isLongDuration) {
-          const hours = Math.floor((countUp ? currentDuration : currentDuration) / 3600);
-          const minutesInHour = Math.floor(((countUp ? currentDuration : currentDuration) % 3600) / 60);
+          const totalForDisplay = countUp ? Math.max(0, time) : Math.max(0, time);
+          const hours = Math.floor(totalForDisplay / 3600);
+          const minutesInHour = Math.floor((totalForDisplay % 3600) / 60);
           const hourStr = String(hours);
           const minuteStr = String(minutesInHour).padStart(2, '0');
 

--- a/src/components/MqtSetting.js
+++ b/src/components/MqtSetting.js
@@ -152,7 +152,7 @@ const MqtSetting = () => {
       <Slider
         size="small"
         min={1}
-        max={limitBreak ? 999 : 120}
+        max={limitBreak ? 43200 : 120}
         value={duration}
         onChange={(e, v) => setDuration(v)}
       />

--- a/src/components/MqtSetting.js
+++ b/src/components/MqtSetting.js
@@ -314,7 +314,7 @@ const MqtSetting = () => {
           onClick={handleStart}
           sx={{ mr: 2 }} // Adds margin-right for spacing
         >
-          Start
+          Preview
         </Button>
 
         <Button


### PR DESCRIPTION
## Purpose

Users requested improvements to the dynamic timer format switching behavior. The original implementation switched from MM/MM:SS to HHMM/HH:MM formats at 56 minutes, but this caused issues with proper format transitions when decrementing time. Users wanted the threshold increased to 120 minutes to provide better usability and prevent premature format switching that interfered with normal timer operation.

## Code changes

- **Updated format switching threshold**: Changed from 56 minutes to 120 minutes for triggering hour-inclusive display formats
- **Added `isLongDuration` logic**: Introduced new condition `Math.floor(currentTotalSeconds / 60) > 120` to determine when to use HHMM/HH:MM formats
- **Enhanced font sizing**: Added specific font size calculations for long duration formats with proper digit count handling
- **Improved digit clicking**: Added support for `hours` and `minutesWithinHour` digit types to handle hour-based format interactions
- **Fixed format transitions**: Ensured proper switching between MM ↔ HHMM and MM:SS ↔ HH:MM when crossing the 120-minute threshold
- **Updated button text**: Changed "Start" to "Preview" in settings component
- **Optimized font constraints**: Added width and height constraints to prevent text overflow beyond circle boundaries

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e3661e6812b743e1a74e2d5dafc8a908/zenith-realm)

👀 [Preview Link](https://e3661e6812b743e1a74e2d5dafc8a908-zenith-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e3661e6812b743e1a74e2d5dafc8a908</projectId>-->
<!--<branchName>zenith-realm</branchName>-->